### PR TITLE
Make use of aliases in consolidateBuilderEntries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.6.1
+	github.com/stretchr/testify v1.8.1
 	github.com/tdewolff/minify v2.3.6+incompatible
 	go.uber.org/atomic v1.10.0
 	golang.org/x/text v0.4.0
@@ -26,6 +27,7 @@ require (
 	github.com/VictoriaMetrics/fastcache v1.6.0 // indirect
 	github.com/btcsuite/btcd/btcec/v2 v2.3.2 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/deckarep/golang-set v1.8.0 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0 // indirect
 	github.com/ferranbt/fastssz v0.1.2-0.20220723134332-b3d3034a4575 // indirect
@@ -44,6 +46,7 @@ require (
 	github.com/onsi/ginkgo v1.16.5 // indirect
 	github.com/onsi/gomega v1.21.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/tsdb v0.7.1 // indirect
 	github.com/r3labs/sse/v2 v2.8.1 // indirect
 	github.com/rjeczalik/notify v0.9.1 // indirect
@@ -63,4 +66,5 @@ require (
 	gopkg.in/cenkalti/backoff.v1 v1.1.0 // indirect
 	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -461,6 +461,7 @@ github.com/status-im/keycard-go v0.0.0-20190316090335-8537d3370df4/go.mod h1:RZL
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.2.0/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
@@ -471,6 +472,7 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/supranational/blst v0.3.8-0.20220526154634-513d2456b344 h1:m+8fKfQwCAy1QjzINvKe/pYtLjo2dl59x2w9YSEJxuY=
 github.com/supranational/blst v0.3.8-0.20220526154634-513d2456b344/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
 github.com/syndtr/goleveldb v1.0.1-0.20210305035536-64b5b1c73954/go.mod h1:u2MKkTVTVJWe5D1rCvame8WqhBd88EuIwODJZ1VHCPM=

--- a/services/website/utils.go
+++ b/services/website/utils.go
@@ -140,27 +140,23 @@ func consolidateBuilderEntries(builders []*database.TopBuilderEntry) []*database
 	buildersNumPayloads := uint64(0)
 	for _, entry := range builders {
 		buildersNumPayloads += entry.NumBlocks
-		if strings.Contains(entry.ExtraData, "builder0x69") {
-			topBuilderEntry, isKnown := buildersMap["builder0x69"]
+		if len(entry.Aliases) != 0 {
+			// Aliases[0] must be the same among all aliases.
+			mainAlias := entry.Aliases[0]
+			topBuilderEntry, isKnown := buildersMap[mainAlias]
 			if isKnown {
 				topBuilderEntry.NumBlocks += entry.NumBlocks
 				topBuilderEntry.Aliases = append(topBuilderEntry.Aliases, entry.ExtraData)
-			} else {
-				buildersMap["builder0x69"] = &database.TopBuilderEntry{
-					ExtraData: "builder0x69",
-					NumBlocks: entry.NumBlocks,
-					Aliases:   []string{entry.ExtraData},
-				}
+				continue
+			}
+			buildersMap[mainAlias] = &database.TopBuilderEntry{
+				ExtraData: mainAlias,
+				NumBlocks: entry.NumBlocks,
+				Aliases:   []string{entry.ExtraData},
 			}
 		} else {
 			buildersMap[entry.ExtraData] = entry
 		}
-	}
-
-	// Prepare top builders by extra stats
-	for _, entry := range builders {
-		p := float64(entry.NumBlocks) / float64(buildersNumPayloads) * 100
-		entry.Percent = fmt.Sprintf("%.2f", p)
 	}
 
 	// Prepare top builders by summary stats

--- a/services/website/utils_test.go
+++ b/services/website/utils_test.go
@@ -1,0 +1,66 @@
+package website
+
+import (
+	"testing"
+
+	"github.com/flashbots/relayscan/database"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConsolidateBuilderEntries(t *testing.T) {
+	in := []*database.TopBuilderEntry{
+		{
+			ExtraData: "made by builder0x69",
+			NumBlocks: 1,
+			Aliases:   []string{"builder0x69"},
+		},
+		{
+			ExtraData: "builder0x69",
+			NumBlocks: 1,
+			Aliases:   []string{"builder0x69"},
+		},
+		{
+			ExtraData: "s3e6f",
+			NumBlocks: 1,
+			Aliases:   []string{"bob the builder"},
+		},
+		{
+			ExtraData: "s0e3f",
+			NumBlocks: 1,
+			Aliases:   []string{"bob the builder"},
+		},
+		{
+			ExtraData: "s0e2ts10e11t",
+			NumBlocks: 1,
+			Aliases:   []string{"bob the builder"},
+		},
+		{
+			ExtraData: "manta-builder",
+			NumBlocks: 1,
+		},
+	}
+	expected := []*database.TopBuilderEntry{
+		{
+			ExtraData: "bob the builder",
+			NumBlocks: 3,
+			Percent:   "50.00",
+			Aliases:   []string{"s3e6f", "s0e3f", "s0e2ts10e11t"},
+		},
+		{
+			ExtraData: "builder0x69",
+			NumBlocks: 2,
+			Percent:   "33.33",
+			Aliases:   []string{"made by builder0x69", "builder0x69"},
+		},
+		{
+			ExtraData: "manta-builder",
+			Percent:   "16.67",
+			NumBlocks: 1,
+		},
+	}
+
+	out := consolidateBuilderEntries(in)
+	for i, o := range out {
+		require.Equal(t, expected[i], o)
+	}
+}


### PR DESCRIPTION
## 📝 Summary
In order to handle builders who submit blocks with different `ExtraData`, we can make use of the `Aliases` field as we run `consolidateBuilderEntries`. The precondition here is that each builder entry that belongs to the same group has the same first element in their `Aliases` slice in the DB. This code modifies the logic to check for this rather than specifically handle the `builder0x69` case with a string match. 

I added a simple test to confirm this functionality!

## ⛱ Motivation and Context
Especially near the bottom of the builder list, there is a single builder who has many entries in the table. The builder submits with extra data that matches the regex `s[0-9]e[0-9].*(t|f)`, and in this photo below, over half of the entries in the table are from them. This PR aims at improving the readability of this list by allowing us to merge these entries using an alias list.
 
![Screen Shot 2023-03-01 at 9 25 41 PM](https://user-images.githubusercontent.com/24661810/222547507-4f453194-44c1-47e5-9668-a82e9f1f2ad2.png)

## 📚 References

N/A

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
