### PR TITLE
builder profitability consolidation

### DIFF
--- a/services/website/utils.go
+++ b/services/website/utils.go
@@ -195,29 +195,36 @@ func consolidateBuilderProfitEntries(entries []*database.BuilderProfitEntry) []*
 	buildersNumPayloads := uint64(0)
 	for _, entry := range entries {
 		buildersNumPayloads += entry.NumBlocks
-		if strings.Contains(entry.ExtraData, "builder0x69") {
-			entryConsolidated, isKnown := buildersMap["builder0x69"]
-			if isKnown {
-				entryConsolidated.Aliases = append(entryConsolidated.Aliases, entry.ExtraData)
-				entryConsolidated.NumBlocks += entry.NumBlocks
-				entryConsolidated.NumBlocksProfit += entry.NumBlocksProfit
-				entryConsolidated.NumBlocksSubsidised += entry.NumBlocksSubsidised
-				entryConsolidated.ProfitTotal = addFloatStrings(entryConsolidated.ProfitTotal, entry.ProfitTotal, 4)
-				entryConsolidated.SubsidiesTotal = addFloatStrings(entryConsolidated.SubsidiesTotal, entry.SubsidiesTotal, 4)
-				entryConsolidated.ProfitPerBlockAvg = divFloatStrings(entryConsolidated.ProfitTotal, fmt.Sprint(entryConsolidated.NumBlocks), 4)
-			} else {
-				buildersMap["builder0x69"] = &database.BuilderProfitEntry{
-					ExtraData:           "builder0x69",
-					NumBlocks:           entry.NumBlocks,
-					NumBlocksProfit:     entry.NumBlocksProfit,
-					NumBlocksSubsidised: entry.NumBlocksSubsidised,
-					ProfitTotal:         entry.ProfitTotal,
-					SubsidiesTotal:      entry.SubsidiesTotal,
-					ProfitPerBlockAvg:   entry.ProfitPerBlockAvg,
-					Aliases:             []string{entry.ExtraData},
+		updated := false
+		for k, v := range aliases {
+			// Check if this is one of the known aliases.
+			if v(entry.ExtraData) {
+				updated = true
+				entryConsolidated, isKnown := buildersMap[k]
+				if isKnown {
+					entryConsolidated.Aliases = append(entryConsolidated.Aliases, entry.ExtraData)
+					entryConsolidated.NumBlocks += entry.NumBlocks
+					entryConsolidated.NumBlocksProfit += entry.NumBlocksProfit
+					entryConsolidated.NumBlocksSubsidised += entry.NumBlocksSubsidised
+					entryConsolidated.ProfitTotal = addFloatStrings(entryConsolidated.ProfitTotal, entry.ProfitTotal, 4)
+					entryConsolidated.SubsidiesTotal = addFloatStrings(entryConsolidated.SubsidiesTotal, entry.SubsidiesTotal, 4)
+					entryConsolidated.ProfitPerBlockAvg = divFloatStrings(entryConsolidated.ProfitTotal, fmt.Sprint(entryConsolidated.NumBlocks), 4)
+				} else {
+					buildersMap[k] = &database.BuilderProfitEntry{
+						ExtraData:           k,
+						NumBlocks:           entry.NumBlocks,
+						NumBlocksProfit:     entry.NumBlocksProfit,
+						NumBlocksSubsidised: entry.NumBlocksSubsidised,
+						ProfitTotal:         entry.ProfitTotal,
+						SubsidiesTotal:      entry.SubsidiesTotal,
+						ProfitPerBlockAvg:   entry.ProfitPerBlockAvg,
+						Aliases:             []string{entry.ExtraData},
+					}
 				}
+				break
 			}
-		} else {
+		}
+		if !updated {
 			buildersMap[entry.ExtraData] = entry
 		}
 	}

--- a/services/website/utils_test.go
+++ b/services/website/utils_test.go
@@ -64,3 +64,80 @@ func TestConsolidateBuilderEntries(t *testing.T) {
 		require.Equal(t, expected[i], o)
 	}
 }
+
+func TestConsolidateBuilderProfitEntries(t *testing.T) {
+	in := []*database.BuilderProfitEntry{
+		{
+			ExtraData:       "made by builder0x69",
+			NumBlocks:       1,
+			NumBlocksProfit: 1,
+			ProfitTotal:     "1",
+			Aliases:         []string{"builder0x69"},
+		},
+		{
+			ExtraData:       "builder0x69",
+			NumBlocks:       1,
+			NumBlocksProfit: 1,
+			ProfitTotal:     "1",
+			Aliases:         []string{"builder0x69"},
+		},
+		{
+			ExtraData:           "s3e6f",
+			NumBlocks:           1,
+			NumBlocksSubsidised: 1,
+			SubsidiesTotal:      "1",
+			Aliases:             []string{"bob the builder"},
+		},
+		{
+			ExtraData:           "s0e3f",
+			NumBlocks:           1,
+			NumBlocksSubsidised: 1,
+			SubsidiesTotal:      "1",
+			Aliases:             []string{"bob the builder"},
+		},
+		{
+			ExtraData:           "s0e2ts10e11t",
+			NumBlocks:           1,
+			NumBlocksSubsidised: 1,
+			SubsidiesTotal:      "1",
+			Aliases:             []string{"bob the builder"},
+		},
+		{
+			ExtraData:       "manta-builder",
+			NumBlocks:       1,
+			NumBlocksProfit: 1,
+			ProfitTotal:     "3",
+		},
+	}
+	expected := []*database.BuilderProfitEntry{
+		{
+			ExtraData:       "manta-builder",
+			NumBlocks:       1,
+			NumBlocksProfit: 1,
+			ProfitTotal:     "3",
+		},
+		{
+			ExtraData:         "builder0x69",
+			NumBlocks:         2,
+			NumBlocksProfit:   2,
+			ProfitTotal:       "2.0000",
+			ProfitPerBlockAvg: "1.0000",
+			SubsidiesTotal:    "0.0000",
+			Aliases:           []string{"made by builder0x69", "builder0x69"},
+		},
+		{
+			ExtraData:           "bob the builder",
+			NumBlocks:           3,
+			NumBlocksSubsidised: 3,
+			ProfitTotal:         "0.0000",
+			ProfitPerBlockAvg:   "0.0000",
+			SubsidiesTotal:      "3.0000",
+			Aliases:             []string{"s3e6f", "s0e3f", "s0e2ts10e11t"},
+		},
+	}
+
+	out := consolidateBuilderProfitEntries(in)
+	for i, o := range out {
+		require.Equal(t, expected[i], o)
+	}
+}


### PR DESCRIPTION
## 📝 Summary
Extending https://github.com/flashbots/relayscan/pull/1 to the builder profitability table. 

## ⛱ Motivation and Context
See https://github.com/flashbots/relayscan/pull/1. 

## 📚 References

N/A

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
