### PR TITLE
supporting s12e14t

### DIFF
--- a/services/website/utils.go
+++ b/services/website/utils.go
@@ -29,7 +29,7 @@ var (
 			return strings.Contains(in, "builder0x69")
 		},
 		"bob the builder": func(in string) bool {
-			match, _ := regexp.MatchString("s[0-9]e[0-9].*(t|f)", in)
+			match, _ := regexp.MatchString("s[0-9]+e[0-9].*(t|f)", in)
 			return match
 		},
 	}

--- a/services/website/utils_test.go
+++ b/services/website/utils_test.go
@@ -96,6 +96,13 @@ func TestConsolidateBuilderProfitEntries(t *testing.T) {
 			Aliases:             []string{"bob the builder"},
 		},
 		{
+			ExtraData:           "s12e14t",
+			NumBlocks:           1,
+			NumBlocksSubsidised: 1,
+			SubsidiesTotal:      "1",
+			Aliases:             []string{"bob the builder"},
+		},
+		{
 			ExtraData:           "s0e2ts10e11t",
 			NumBlocks:           1,
 			NumBlocksSubsidised: 1,
@@ -127,12 +134,12 @@ func TestConsolidateBuilderProfitEntries(t *testing.T) {
 		},
 		{
 			ExtraData:           "bob the builder",
-			NumBlocks:           3,
-			NumBlocksSubsidised: 3,
+			NumBlocks:           4,
+			NumBlocksSubsidised: 4,
 			ProfitTotal:         "0.0000",
 			ProfitPerBlockAvg:   "0.0000",
-			SubsidiesTotal:      "3.0000",
-			Aliases:             []string{"s3e6f", "s0e3f", "s0e2ts10e11t"},
+			SubsidiesTotal:      "4.0000",
+			Aliases:             []string{"s3e6f", "s0e3f", "s12e14t", "s0e2ts10e11t"},
 		},
 	}
 


### PR DESCRIPTION
## 📝 Summary

Adding support for multiple digits after the initial `s`. 

## ⛱ Motivation and Context
`s12e14t` is not bundled into bob's blocks.

<img width="672" alt="Screen Shot 2023-03-15 at 12 13 47 PM" src="https://user-images.githubusercontent.com/24661810/225404405-2d2529b7-b59b-427b-a7e1-ccece99b8c1b.png">


## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
