### PR TITLE
[fix] Don't panic on errors if no backup RPC is configured

### DIFF
--- a/cmd/core/check-payload-value.go
+++ b/cmd/core/check-payload-value.go
@@ -48,12 +48,18 @@ var checkPayloadValueCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		var err error
 
-		log.Infof("Using eth node: %s", ethNodeURI)
 		client := flashbotsrpc.New(ethNodeURI)
-		var client2 *flashbotsrpc.FlashbotsRPC
+		if client == nil {
+			log.Fatalf("Failed to create RPC client for '%s'", ethNodeURI)
+		}
+		log.Infof("Using eth node: %s", client.URL())
+		client2 := client
 		if ethNodeBackupURI != "" {
-			log.Infof("Using eth backup node: %s", ethNodeBackupURI)
 			client2 = flashbotsrpc.New(ethNodeBackupURI)
+			if client2 == nil {
+				log.Fatalf("Failed to create backup RPC client for '%s'", ethNodeBackupURI)
+			}
+			log.Infof("Using eth backup node: %s", client2.URL())
 		}
 
 		// Connect to Postgres


### PR DESCRIPTION
## 📝 Summary

If no backup RPC endpoint is configured (e.g. via `ETH_NODE_BACKUP_URI`), then RPC call errors end up in panic like:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xc4ea7b]
goroutine 26 [running]:
github.com/metachris/flashbotsrpc.(*FlashbotsRPC).Call(0x0, {0xf1cc1f, 0xe}, {0xc00095a0c0?, 0xdb0320?, 0x1?})
	github.com/metachris/flashbotsrpc@v0.5.0/flashbotsrpc.go:108 +0x17b
github.com/metachris/flashbotsrpc.(*FlashbotsRPC).call(0xc0003ee0a0?, {0xf1cc1f?, 0xc0002fa270?}, {0xd928e0, 0xc0002e60e0}, {0xc00095a0c0?, 0x1?, 0x1?})
	github.com/metachris/flashbotsrpc@v0.5.0/flashbotsrpc.go:77 +0x36
github.com/metachris/flashbotsrpc.(*FlashbotsRPC).EthGetBalance(0xf15130?, {0xc00034d080, 0x2a}, {0xc0003ee0a0, 0x9})
	github.com/metachris/flashbotsrpc@v0.5.0/flashbotsrpc.go:351 +0x105
github.com/flashbots/relayscan/cmd/core._getBalanceDiff(0x4?, {0xc00034d080, 0x2a}, 0x11526a8)
	github.com/flashbots/relayscan/cmd/core/check-payload-value.go:127 +0xa9
github.com/flashbots/relayscan/cmd/core.startUpdateWorker.func1({0xc00034d080, 0x2a}, 0xc00034d080?)
	github.com/flashbots/relayscan/cmd/core/check-payload-value.go:146 +0x65
github.com/flashbots/relayscan/cmd/core.startUpdateWorker(0xc00037ff70?, 0xc000012288?, 0xc000240820?, 0x0?, 0xc000040060?)
	github.com/flashbots/relayscan/cmd/core/check-payload-value.go:256 +0x91a
created by github.com/flashbots/relayscan/cmd/core.glob..func1
	github.com/flashbots/relayscan/cmd/core/check-payload-value.go:115 +0x93b
```

## ⛱ Motivation and Context

Let's assign the same main client to the backup in situations when no backup config is provided.  This will simply make us re-try same request to the same backend.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
