### PR TITLE
fix batch save

### DIFF
--- a/cmd/core/data-api-backfill.go
+++ b/cmd/core/data-api-backfill.go
@@ -53,6 +53,7 @@ var backfillDataAPICmd = &cobra.Command{
 			}
 		}
 
+		log.Infof("Relayscan %s", vars.Version)
 		log.Infof("Using %d relays", len(relays))
 		for index, relay := range relays {
 			log.Infof("relay #%d: %s", index+1, relay.Hostname())


### PR DESCRIPTION
## 📝 Summary

Fixes error when batch-saving hits postgres limit of 65535 parameters at a time

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
