### PR TITLE
add `--redis` flag

### DIFF
--- a/cmd/service/bidcollect.go
+++ b/cmd/service/bidcollect.go
@@ -128,6 +128,7 @@ var bidCollectCmd = &cobra.Command{
 			OutDir:                  outDir,
 			OutputTSV:               outputTSV,
 			RedisAddr:               redisAddr,
+			UseRedis:                useRedis,
 		}
 
 		bidCollector, err := bidcollect.NewBidCollector(&opts)

--- a/services/bidcollect/bid-processor.go
+++ b/services/bidcollect/bid-processor.go
@@ -27,6 +27,7 @@ type BidProcessorOpts struct {
 	OutDir    string
 	OutputTSV bool
 	RedisAddr string
+	UseRedis  bool
 }
 
 type OutFiles struct {
@@ -68,7 +69,7 @@ func NewBidProcessor(opts *BidProcessorOpts) (*BidProcessor, error) {
 		c.csvFileEnding = "csv"
 	}
 
-	if opts.RedisAddr != "" {
+	if opts.UseRedis && opts.RedisAddr != "" {
 		c.redisClient = redis.NewClient(&redis.Options{
 			Addr:     opts.RedisAddr,
 			Password: "", // no password set

--- a/services/bidcollect/bidcollector.go
+++ b/services/bidcollect/bidcollector.go
@@ -22,6 +22,7 @@ type BidCollectorOpts struct {
 	OutputTSV bool
 
 	RedisAddr string
+	UseRedis  bool
 }
 
 type BidCollector struct {
@@ -57,6 +58,7 @@ func NewBidCollector(opts *BidCollectorOpts) (c *BidCollector, err error) {
 		OutDir:    opts.OutDir,
 		OutputTSV: opts.OutputTSV,
 		RedisAddr: opts.RedisAddr,
+		UseRedis:  opts.UseRedis,
 	})
 	return c, err
 }


### PR DESCRIPTION
## 📝 Summary

edit bidcollect.go, bid-processor.go and bidcollector.go to accept the `--redis` falg

## ⛱ Motivation and Context

Since [PR50](https://github.com/flashbots/relayscan/pull/50), the default behavior of the bid collector is to assume that there's a redis service running, even if we do not add the `--redis` falg.

<!--- Why is this change required? What problem does it solve? -->
If you run: 
```
go run . service bidcollect --data-api --ultrasound-stream --all-relays
```
You will get this error:
```
failed to create bid collector                error="dial tcp [::1]:6379: connect: connection refused"
exit status 1
```

A workaround is to set `--redis-addr ""`
## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`

`make lint` yields several warnings an errors, non of them seem to be related to this PR