### PR TITLE
Upgrade Builder Aliases to Builder Groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ go run . core check-payload-value --slot <your_slot>
 # Run the website
 go run . service website --dev
 
+# Simplify working with read-only DB or large amount of data:
+ DB_DONT_APPLY_SCHEMA=1 SKIP_7D_STATS=1 go run . service website --dev
+
 # Now you can open http://localhost:9060 in your browser and see the data
 open http://localhost:9060
 

--- a/README.md
+++ b/README.md
@@ -97,16 +97,22 @@ source .env.local
 make dev-postgres-start
 
 # Query only a single relay, and for the shortest time possible
-go run . core data-api-backfill --relay fb --min-slot -2000
+go run . core data-api-backfill --relay us --min-slot -2000
 
 # Now the DB has data, check it (and update in DB)
 go run . core check-payload-value
 
 # Can also check a single slot only:
-go run . core check-payload-value --slot _N_
+go run . core check-payload-value --slot <your_slot>
 
-# Reset DB
-dev-postgres-wipe
+# Run the website
+go run . service website --dev
+
+# Now you can open http://localhost:9060 in your browser and see the data
+open http://localhost:9060
+
+# You can also reset the database:
+make dev-postgres-wipe
 
 # See the Makefile for more commands
 make help

--- a/cmd/core/data-api-backfill.go
+++ b/cmd/core/data-api-backfill.go
@@ -41,6 +41,8 @@ var backfillDataAPICmd = &cobra.Command{
 			var relayEntry common.RelayEntry
 			if cliRelay == "fb" {
 				relayEntry, err = common.NewRelayEntry(vars.RelayURLs[0], false)
+			} else if cliRelay == "us" {
+				relayEntry, err = common.NewRelayEntry(vars.RelayURLs[1], false)
 			} else {
 				relayEntry, err = common.NewRelayEntry(cliRelay, false)
 			}

--- a/database/types.go
+++ b/database/types.go
@@ -152,6 +152,11 @@ type TopBuilderEntry struct {
 	Aliases   []string `json:"aliases,omitempty"`
 }
 
+type TopBuilderDisplayEntry struct {
+	Info     *TopBuilderEntry    `json:"info"`
+	Children []*TopBuilderEntry `json:"children"`
+}
+
 // type RelayProfitability struct {
 // 	Relay       string `db:"relay" json:"relay"`
 // 	TimeSince   time.Time

--- a/database/types.go
+++ b/database/types.go
@@ -152,11 +152,6 @@ type TopBuilderEntry struct {
 	Aliases   []string `json:"aliases,omitempty"`
 }
 
-type TopBuilderDisplayEntry struct {
-	Info     *TopBuilderEntry   `json:"info"`
-	Children []*TopBuilderEntry `json:"children"`
-}
-
 // type RelayProfitability struct {
 // 	Relay       string `db:"relay" json:"relay"`
 // 	TimeSince   time.Time

--- a/database/types.go
+++ b/database/types.go
@@ -153,7 +153,7 @@ type TopBuilderEntry struct {
 }
 
 type TopBuilderDisplayEntry struct {
-	Info     *TopBuilderEntry    `json:"info"`
+	Info     *TopBuilderEntry   `json:"info"`
 	Children []*TopBuilderEntry `json:"children"`
 }
 

--- a/services/website/html.go
+++ b/services/website/html.go
@@ -16,17 +16,17 @@ type Stats struct {
 	TimeStr string // i.e. 24h, 12h, 1h or 7d
 
 	TopRelays          []*database.TopRelayEntry
-	TopBuilders        []*database.TopBuilderDisplayEntry
+	TopBuilders        []*TopBuilderDisplayEntry
 	BuilderProfits     []*database.BuilderProfitEntry
-	TopBuildersByRelay map[string][]*database.TopBuilderDisplayEntry
+	TopBuildersByRelay map[string][]*TopBuilderDisplayEntry
 }
 
 func NewStats() *Stats {
 	return &Stats{
 		TopRelays:          make([]*database.TopRelayEntry, 0),
-		TopBuilders:        make([]*database.TopBuilderDisplayEntry, 0),
+		TopBuilders:        make([]*TopBuilderDisplayEntry, 0),
 		BuilderProfits:     make([]*database.BuilderProfitEntry, 0),
-		TopBuildersByRelay: make(map[string][]*database.TopBuilderDisplayEntry),
+		TopBuildersByRelay: make(map[string][]*TopBuilderDisplayEntry),
 	}
 }
 
@@ -53,7 +53,7 @@ type HTMLDataDailyStats struct {
 	TimeUntil string
 
 	TopRelays            []*database.TopRelayEntry
-	TopBuildersBySummary []*database.TopBuilderDisplayEntry
+	TopBuildersBySummary []*TopBuilderDisplayEntry
 	BuilderProfits       []*database.BuilderProfitEntry
 }
 

--- a/services/website/html.go
+++ b/services/website/html.go
@@ -58,14 +58,15 @@ type HTMLDataDailyStats struct {
 }
 
 var funcMap = template.FuncMap{
-	"weiToEth":           weiToEth,
-	"prettyInt":          prettyInt,
-	"caseIt":             caseIt,
-	"percent":            percent,
-	"relayTable":         relayTable,
-	"builderTable":       builderTable,
-	"builderProfitTable": builderProfitTable,
-	"humanTime":          humanize.Time,
+	"weiToEth":              weiToEth,
+	"prettyInt":             prettyInt,
+	"caseIt":                caseIt,
+	"percent":               percent,
+	"relayTable":            relayTable,
+	"builderTable":          builderTable,
+	"builderProfitTable":    builderProfitTable,
+	"humanTime":             humanize.Time,
+	"lowercaseNoWhitespace": lowercaseNoWhitespace,
 }
 
 func ParseIndexTemplate() (*template.Template, error) {

--- a/services/website/html.go
+++ b/services/website/html.go
@@ -16,17 +16,17 @@ type Stats struct {
 	TimeStr string // i.e. 24h, 12h, 1h or 7d
 
 	TopRelays          []*database.TopRelayEntry
-	TopBuilders        []*database.TopBuilderEntry
+	TopBuilders        []*database.TopBuilderDisplayEntry
 	BuilderProfits     []*database.BuilderProfitEntry
-	TopBuildersByRelay map[string][]*database.TopBuilderEntry
+	TopBuildersByRelay map[string][]*database.TopBuilderDisplayEntry
 }
 
 func NewStats() *Stats {
 	return &Stats{
 		TopRelays:          make([]*database.TopRelayEntry, 0),
-		TopBuilders:        make([]*database.TopBuilderEntry, 0),
+		TopBuilders:        make([]*database.TopBuilderDisplayEntry, 0),
 		BuilderProfits:     make([]*database.BuilderProfitEntry, 0),
-		TopBuildersByRelay: make(map[string][]*database.TopBuilderEntry),
+		TopBuildersByRelay: make(map[string][]*database.TopBuilderDisplayEntry),
 	}
 }
 
@@ -53,7 +53,7 @@ type HTMLDataDailyStats struct {
 	TimeUntil string
 
 	TopRelays            []*database.TopRelayEntry
-	TopBuildersBySummary []*database.TopBuilderEntry
+	TopBuildersBySummary []*database.TopBuilderDisplayEntry
 	BuilderProfits       []*database.BuilderProfitEntry
 }
 

--- a/services/website/templates/base.html
+++ b/services/website/templates/base.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/purecss@3.0.0/build/grids-min.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/purecss@3.0.0/build/grids-responsive-min.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.2/font/bootstrap-icons.css">
-    <link rel="stylesheet" href="/static/styles.css?v=10">
+    <link rel="stylesheet" href="/static/styles.css?v=11">
 
     <link rel="apple-touch-icon" sizes="180x180" href="/static/favicon/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/static/favicon/favicon-32x32.png">

--- a/services/website/templates/daily-stats.html
+++ b/services/website/templates/daily-stats.html
@@ -22,6 +22,7 @@
                             <th>Relay</th>
                             <th>Payloads</th>
                             <th>Percent</th>
+                            <th></th>
                         </tr>
                     </thead>
                     <tbody id="tbody-relays" class="tbody-relays">
@@ -49,11 +50,22 @@
                     </thead>
                     <tbody id="tbody-builders-all" class="tbody-builders">
                         {{ range .TopBuildersBySummary }}
-                        <tr>
-                            <td class="td-builder-extradata">{{ if .ExtraData }}{{ .ExtraData }}{{ else }}&nbsp;{{ end }}</td>
+                        <tr class="tr-builder-parent">
+                            <td class="td-builder-extradata">{{ if .Info.ExtraData }}{{ .Info.ExtraData }}{{ else }}&nbsp;{{ end }}</td>
+                            <td class="td-builder-num-blocks">{{ .Info.NumBlocks | prettyInt }}</td>
+                            <td class="td-builder-percent">{{ .Info.Percent }} %</td>
+                            <td>{{ if gt (len .Children) 1 }}<i class="bi bi-caret-down"></i>{{ end }}</td>
+                        </tr>
+                        {{ if gt (len .Children) 1 }}
+                        {{ range .Children }}
+                        <tr class="tr-builder-child">
+                            <td class="td-builder-extradata td-builder-extradata-child" style="margin-left: 10px;">{{ .ExtraData }}</td>
                             <td class="td-builder-num-blocks">{{ .NumBlocks | prettyInt }}</td>
                             <td class="td-builder-percent">{{ .Percent }} %</td>
+                            <td></td>
                         </tr>
+                        {{ end }}
+                        {{ end }}
                         {{ end }}
                     </tbody>
                 </table>

--- a/services/website/templates/daily-stats.html
+++ b/services/website/templates/daily-stats.html
@@ -50,24 +50,7 @@
                     <tbody id="tbody-builders-all" class="tbody-builders">
                         {{ range .TopBuildersBySummary }}
                         <tr>
-                            <td class="td-builder-extradata">
-                                {{ if .ExtraData }}{{ .ExtraData }}{{ else }}&nbsp;{{ end }}
-                                {{ if ne (len .Aliases) 0 }}
-                                <span class="tooltip-wrapper">
-                                    <i class="tooltip-icon bi bi-info-circle" aria-describedby="tooltip-builder-alias"></i>
-                                    <div id="tooltip-builder-alias" class="tooltip builder-aliases" role="tooltip">
-                                        <b>extra_data values:</b>
-                                        <ul>
-                                            {{ range .Aliases }}
-                                            <li>{{ . }}</li>
-                                            {{ end }}
-                                        </ul>
-                                        <div id="arrow" data-popper-arrow></div>
-                                    </div>
-                                </span>
-                                {{ end }}
-
-                            </td>
+                            <td class="td-builder-extradata">{{ if .ExtraData }}{{ .ExtraData }}{{ else }}&nbsp;{{ end }}</td>
                             <td class="td-builder-num-blocks">{{ .NumBlocks | prettyInt }}</td>
                             <td class="td-builder-percent">{{ .Percent }} %</td>
                         </tr>

--- a/services/website/templates/index.html
+++ b/services/website/templates/index.html
@@ -66,7 +66,8 @@
                     </thead>
                     <tbody id="tbody-builders-all" class="tbody-builders">
                         {{ range .Stats.TopBuilders }}
-                        <tr class="tr-builder-parent">
+                        {{ $parent := .Info.ExtraData | lowercaseNoWhitespace }}
+                        <tr class="tr-builder-parent" onclick="toggleBuilderChildren('{{ $parent }}');">
                             <td class="td-builder-extradata">{{ if .Info.ExtraData }}{{ .Info.ExtraData }}{{ else }}&nbsp;{{ end }}</td>
                             <td class="td-builder-num-blocks">{{ .Info.NumBlocks | prettyInt }}</td>
                             <td class="td-builder-percent">{{ .Info.Percent }} %</td>
@@ -74,7 +75,7 @@
                         </tr>
                         {{ if gt (len .Children) 1 }}
                         {{ range .Children }}
-                        <tr class="tr-builder-child">
+                        <tr class="tr-builder-child builder-child-{{ $parent }}">
                             <td class="td-builder-extradata td-builder-extradata-child" style="margin-left: 10px;">{{ .ExtraData }}</td>
                             <td class="td-builder-num-blocks">{{ .NumBlocks | prettyInt }}</td>
                             <td class="td-builder-percent">{{ .Percent }} %</td>
@@ -301,6 +302,17 @@
     window.onload = (event) => {
         // fix for table sorting (it's already sorted, and this click makes the sortable plugin think it has done it)
         document.getElementById("th-builderprofit-profittotal").click()
+    }
+
+    toggleBuilderChildren = function (parent) {
+        var children = document.getElementsByClassName("builder-child-" + parent);
+        for (var i = 0; i < children.length; i++) {
+            if (children[i].style.display === "none") {
+                children[i].style.display = "table-row";
+            } else {
+                children[i].style.display = "none";
+            }
+        }
     }
 </script>
 

--- a/services/website/templates/index.html
+++ b/services/website/templates/index.html
@@ -61,20 +61,21 @@
                             <th>Builder (extra_data)</th>
                             <th>Blocks</th>
                             <th style="min-width: 100px;">Percent</th>
+                            <th></th>
                         </tr>
                     </thead>
                     <tbody id="tbody-builders-all" class="tbody-builders">
                         {{ range .Stats.TopBuilders }}
-                        <tr>
+                        <tr class="tr-parent">
                             <td class="td-builder-extradata">
-                                {{ if .ExtraData }}{{ .ExtraData }}{{ else }}&nbsp;{{ end }}
-                                {{ if ne (len .Aliases) 0 }}
+                                {{ if .Info.ExtraData }}{{ .Info.ExtraData }}{{ else }}&nbsp;{{ end }}
+                                {{ if ne (len .Info.Aliases) 0 }}
                                 <span class="tooltip-wrapper">
                                     <i class="tooltip-icon bi bi-info-circle" aria-describedby="tooltip-builder-alias"></i>
                                     <div id="tooltip-builder-alias" class="tooltip builder-aliases" role="tooltip">
                                         <b>extra_data values:</b>
                                         <ul>
-                                            {{ range .Aliases }}
+                                            {{ range .Info.Aliases }}
                                             <li>{{ . }}</li>
                                             {{ end }}
                                         </ul>
@@ -82,11 +83,23 @@
                                     </div>
                                 </span>
                                 {{ end }}
-
                             </td>
-                            <td class="td-builder-num-blocks">{{ .NumBlocks | prettyInt }}</td>
-                            <td class="td-builder-percent">{{ .Percent }} %</td>
+                            <td class="td-builder-num-blocks">{{ .Info.NumBlocks | prettyInt }}</td>
+                            <td class="td-builder-percent">{{ .Info.Percent }} %</td>
+                            <td>
+                                {{ if ne (len .Children) 0 }}
+                                <span class="chevron">⌄</span>
+                                {{ end }}
+                            </td>
                         </tr>
+                            {{ range .Children }}
+                            <tr class="tr-child" style="background-color: rgb(243, 241, 241);">
+                                <td class="td-builder-extradata td-builder-extradata-child" style="margin-left: 10px;">{{ .ExtraData }}</td>
+                                <td class="td-builder-num-blocks">{{ .NumBlocks | prettyInt }}</td>
+                                <td class="td-builder-percent">{{ .Percent }} %</td>
+                                <td></td>
+                            </tr>
+                            {{ end }}
                         {{ end }}
                     </tbody>
 
@@ -95,13 +108,13 @@
                         {{ range $builders }}
                         <tr>
                             <td class="td-builder-extradata">
-                                {{ if .ExtraData }}{{ .ExtraData }}{{ else }}&nbsp;{{ end }}
-                                {{ if ne (len .Aliases) 0 }}
+                                {{ if .Info.ExtraData }}{{ .Info.ExtraData }}{{ else }}&nbsp;{{ end }}
+                                {{ if ne (len .Info.Aliases) 0 }}
                                 <i class="tooltip-icon bi bi-info-circle" aria-describedby="tooltip-builder-alias"></i>
                                 {{ end}}
                             </td>
-                            <td class="td-builder-num-blocks">{{ .NumBlocks | prettyInt }}</td>
-                            <td class="td-builder-percent">{{ .Percent }} %</td>
+                            <td class="td-builder-num-blocks">{{ .Info.NumBlocks | prettyInt }}</td>
+                            <td class="td-builder-percent">{{ .Info.Percent }} %</td>
                         </tr>
                         {{ end }}
                     </tbody>

--- a/services/website/templates/index.html
+++ b/services/website/templates/index.html
@@ -70,11 +70,7 @@
                             <td class="td-builder-extradata">{{ if .Info.ExtraData }}{{ .Info.ExtraData }}{{ else }}&nbsp;{{ end }}</td>
                             <td class="td-builder-num-blocks">{{ .Info.NumBlocks | prettyInt }}</td>
                             <td class="td-builder-percent">{{ .Info.Percent }} %</td>
-                            <td>
-                                {{ if gt (len .Children) 1 }}
-                                <span class="chevron"><i class="bi bi-caret-down"></i></span>
-                                {{ end }}
-                            </td>
+                            <td>{{ if gt (len .Children) 1 }}<i class="bi bi-caret-down"></i>{{ end }}</td>
                         </tr>
                         {{ if gt (len .Children) 1 }}
                         {{ range .Children }}
@@ -92,16 +88,22 @@
                     {{ range $relay, $builders := .Stats.TopBuildersByRelay }}
                     <tbody id="tbody-builders-{{ $relay }}" class="tbody-builders" style="display:none;">
                         {{ range $builders }}
-                        <tr>
-                            <td class="td-builder-extradata">
-                                {{ if .Info.ExtraData }}{{ .Info.ExtraData }}{{ else }}&nbsp;{{ end }}
-                                {{ if ne (len .Info.Aliases) 0 }}
-                                <i class="tooltip-icon bi bi-info-circle" aria-describedby="tooltip-builder-alias"></i>
-                                {{ end}}
-                            </td>
+                        <tr class="tr-builder-parent">
+                            <td class="td-builder-extradata">{{ if .Info.ExtraData }}{{ .Info.ExtraData }}{{ else }}&nbsp;{{ end }}</td>
                             <td class="td-builder-num-blocks">{{ .Info.NumBlocks | prettyInt }}</td>
                             <td class="td-builder-percent">{{ .Info.Percent }} %</td>
+                            <td>{{ if gt (len .Children) 1 }}<i class="bi bi-caret-down"></i>{{ end }}</td>
                         </tr>
+                        {{ if gt (len .Children) 1 }}
+                        {{ range .Children }}
+                        <tr class="tr-builder-child">
+                            <td class="td-builder-extradata td-builder-extradata-child" style="margin-left: 10px;">{{ .ExtraData }}</td>
+                            <td class="td-builder-num-blocks">{{ .NumBlocks | prettyInt }}</td>
+                            <td class="td-builder-percent">{{ .Percent }} %</td>
+                            <td></td>
+                        </tr>
+                        {{ end }}
+                        {{ end }}
                         {{ end }}
                     </tbody>
                     {{ end }}

--- a/services/website/templates/index.html
+++ b/services/website/templates/index.html
@@ -66,40 +66,26 @@
                     </thead>
                     <tbody id="tbody-builders-all" class="tbody-builders">
                         {{ range .Stats.TopBuilders }}
-                        <tr class="tr-parent">
-                            <td class="td-builder-extradata">
-                                {{ if .Info.ExtraData }}{{ .Info.ExtraData }}{{ else }}&nbsp;{{ end }}
-                                {{ if ne (len .Info.Aliases) 0 }}
-                                <span class="tooltip-wrapper">
-                                    <i class="tooltip-icon bi bi-info-circle" aria-describedby="tooltip-builder-alias"></i>
-                                    <div id="tooltip-builder-alias" class="tooltip builder-aliases" role="tooltip">
-                                        <b>extra_data values:</b>
-                                        <ul>
-                                            {{ range .Info.Aliases }}
-                                            <li>{{ . }}</li>
-                                            {{ end }}
-                                        </ul>
-                                        <div id="arrow" data-popper-arrow></div>
-                                    </div>
-                                </span>
-                                {{ end }}
-                            </td>
+                        <tr class="tr-builder-parent">
+                            <td class="td-builder-extradata">{{ if .Info.ExtraData }}{{ .Info.ExtraData }}{{ else }}&nbsp;{{ end }}</td>
                             <td class="td-builder-num-blocks">{{ .Info.NumBlocks | prettyInt }}</td>
                             <td class="td-builder-percent">{{ .Info.Percent }} %</td>
                             <td>
-                                {{ if ne (len .Children) 0 }}
-                                <span class="chevron">⌄</span>
+                                {{ if gt (len .Children) 1 }}
+                                <span class="chevron"><i class="bi bi-caret-down"></i></span>
                                 {{ end }}
                             </td>
                         </tr>
-                            {{ range .Children }}
-                            <tr class="tr-child" style="background-color: rgb(243, 241, 241);">
-                                <td class="td-builder-extradata td-builder-extradata-child" style="margin-left: 10px;">{{ .ExtraData }}</td>
-                                <td class="td-builder-num-blocks">{{ .NumBlocks | prettyInt }}</td>
-                                <td class="td-builder-percent">{{ .Percent }} %</td>
-                                <td></td>
-                            </tr>
-                            {{ end }}
+                        {{ if gt (len .Children) 1 }}
+                        {{ range .Children }}
+                        <tr class="tr-builder-child">
+                            <td class="td-builder-extradata td-builder-extradata-child" style="margin-left: 10px;">{{ .ExtraData }}</td>
+                            <td class="td-builder-num-blocks">{{ .NumBlocks | prettyInt }}</td>
+                            <td class="td-builder-percent">{{ .Percent }} %</td>
+                            <td></td>
+                        </tr>
+                        {{ end }}
+                        {{ end }}
                         {{ end }}
                     </tbody>
 

--- a/services/website/types.go
+++ b/services/website/types.go
@@ -1,6 +1,13 @@
 package website
 
+import "github.com/flashbots/relayscan/database"
+
 type HTTPErrorResp struct {
 	Code    int    `json:"code"`
 	Message string `json:"message"`
+}
+
+type TopBuilderDisplayEntry struct {
+	Info     *database.TopBuilderEntry   `json:"info"`
+	Children []*database.TopBuilderEntry `json:"children"`
 }

--- a/services/website/utils.go
+++ b/services/website/utils.go
@@ -145,7 +145,6 @@ func consolidateBuilderEntries(builders []*database.TopBuilderEntry) []*database
 
 		updated := false
 
-
 		// Find out if this builder belongs to any group.
 		for k, v := range vars.BuilderGroups {
 			if v(entry.ExtraData) {
@@ -161,14 +160,12 @@ func consolidateBuilderEntries(builders []*database.TopBuilderEntry) []*database
 							NumBlocks: entry.NumBlocks,
 						},
 						Children: []*database.TopBuilderEntry{entry},
-						
 					}
 				}
 				break
 			}
 		}
 
-		
 		// for k, v := range vars.BuilderAliases {
 		// 	// Check if this is one of the known aliases.
 		// 	if v(entry.ExtraData) {
@@ -188,10 +185,9 @@ func consolidateBuilderEntries(builders []*database.TopBuilderEntry) []*database
 		// 	}
 		// }
 
-
 		if !updated {
 			buildersMap[entry.ExtraData] = &database.TopBuilderDisplayEntry{
-				Info: entry,
+				Info:     entry,
 				Children: []*database.TopBuilderEntry{},
 			}
 		}
@@ -202,7 +198,6 @@ func consolidateBuilderEntries(builders []*database.TopBuilderEntry) []*database
 	for _, entry := range buildersMap {
 		p := float64(entry.Info.NumBlocks) / float64(buildersNumPayloads) * 100
 		entry.Info.Percent = fmt.Sprintf("%.2f", p)
-		
 
 		for _, child := range entry.Children {
 			p := float64(child.NumBlocks) / float64(buildersNumPayloads) * 100

--- a/services/website/utils.go
+++ b/services/website/utils.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/flashbots/relayscan/database"
 	"github.com/flashbots/relayscan/vars"
@@ -273,4 +274,13 @@ func getLastWednesday() time.Time {
 		targetDate = targetDate.AddDate(0, 0, -7)
 	}
 	return targetDate
+}
+
+func lowercaseNoWhitespace(str string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsSpace(r) {
+			return -1
+		}
+		return unicode.ToLower(r)
+	}, str)
 }

--- a/services/website/utils.go
+++ b/services/website/utils.go
@@ -166,25 +166,6 @@ func consolidateBuilderEntries(builders []*database.TopBuilderEntry) []*TopBuild
 			}
 		}
 
-		// for k, v := range vars.BuilderAliases {
-		// 	// Check if this is one of the known aliases.
-		// 	if v(entry.ExtraData) {
-		// 		updated = true
-		// 		topBuilderEntry, isKnown := buildersMap[k]
-		// 		if isKnown {
-		// 			topBuilderEntry.NumBlocks += entry.NumBlocks
-		// 			topBuilderEntry.Aliases = append(topBuilderEntry.Aliases, entry.ExtraData)
-		// 		} else {
-		// 			buildersMap[k] = &database.TopBuilderEntry{
-		// 				ExtraData: k,
-		// 				NumBlocks: entry.NumBlocks,
-		// 				Aliases:   []string{entry.ExtraData},
-		// 			}
-		// 		}
-		// 		break
-		// 	}
-		// }
-
 		if !updated {
 			buildersMap[entry.ExtraData] = &TopBuilderDisplayEntry{
 				Info:     entry,
@@ -222,7 +203,7 @@ func consolidateBuilderProfitEntries(entries []*database.BuilderProfitEntry) []*
 	for _, entry := range entries {
 		buildersNumPayloads += entry.NumBlocks
 		updated := false
-		for k, v := range vars.BuilderAliases {
+		for k, v := range vars.BuilderGroups {
 			// Check if this is one of the known aliases.
 			if v(entry.ExtraData) {
 				updated = true

--- a/services/website/utils.go
+++ b/services/website/utils.go
@@ -52,7 +52,7 @@ func percent(cnt, total uint64) string {
 	return printer.Sprintf("%.2f", p)
 }
 
-func builderTable(builders []*database.TopBuilderDisplayEntry) string {
+func builderTable(builders []*TopBuilderDisplayEntry) string {
 	buildersEntries := [][]string{}
 	for _, builder := range builders {
 		buildersEntries = append(buildersEntries, []string{
@@ -136,9 +136,9 @@ func divFloatStrings(f1, f2 string, decimals int) string {
 	return new(big.Float).Quo(bf1, bf2).Text('f', decimals)
 }
 
-func consolidateBuilderEntries(builders []*database.TopBuilderEntry) []*database.TopBuilderDisplayEntry {
+func consolidateBuilderEntries(builders []*database.TopBuilderEntry) []*TopBuilderDisplayEntry {
 	// Get total builder payloads, and build consolidated builder list
-	buildersMap := make(map[string]*database.TopBuilderDisplayEntry)
+	buildersMap := make(map[string]*TopBuilderDisplayEntry)
 	buildersNumPayloads := uint64(0)
 	for _, entry := range builders {
 		buildersNumPayloads += entry.NumBlocks
@@ -154,7 +154,7 @@ func consolidateBuilderEntries(builders []*database.TopBuilderEntry) []*database
 					groupEntry.Info.NumBlocks += entry.NumBlocks
 					groupEntry.Children = append(groupEntry.Children, entry)
 				} else {
-					buildersMap[k] = &database.TopBuilderDisplayEntry{
+					buildersMap[k] = &TopBuilderDisplayEntry{
 						Info: &database.TopBuilderEntry{
 							ExtraData: k,
 							NumBlocks: entry.NumBlocks,
@@ -186,7 +186,7 @@ func consolidateBuilderEntries(builders []*database.TopBuilderEntry) []*database
 		// }
 
 		if !updated {
-			buildersMap[entry.ExtraData] = &database.TopBuilderDisplayEntry{
+			buildersMap[entry.ExtraData] = &TopBuilderDisplayEntry{
 				Info:     entry,
 				Children: []*database.TopBuilderEntry{},
 			}
@@ -194,7 +194,7 @@ func consolidateBuilderEntries(builders []*database.TopBuilderEntry) []*database
 	}
 
 	// Prepare top builders by summary stats
-	resp := []*database.TopBuilderDisplayEntry{}
+	resp := []*TopBuilderDisplayEntry{}
 	for _, entry := range buildersMap {
 		p := float64(entry.Info.NumBlocks) / float64(buildersNumPayloads) * 100
 		entry.Info.Percent = fmt.Sprintf("%.2f", p)

--- a/services/website/utils_test.go
+++ b/services/website/utils_test.go
@@ -20,42 +20,39 @@ func TestConsolidateBuilderEntries(t *testing.T) {
 			Aliases:   []string{"builder0x69"},
 		},
 		{
-			ExtraData: "s3e6f",
-			NumBlocks: 1,
-			Aliases:   []string{"bob the builder"},
-		},
-		{
-			ExtraData: "s0e3f",
-			NumBlocks: 1,
-			Aliases:   []string{"bob the builder"},
-		},
-		{
-			ExtraData: "s0e2ts10e11t",
-			NumBlocks: 1,
-			Aliases:   []string{"bob the builder"},
-		},
-		{
-			ExtraData: "manta-builder",
+			ExtraData: "foo-builder",
 			NumBlocks: 1,
 		},
 	}
-	expected := []*database.TopBuilderEntry{
+	expected := []*TopBuilderDisplayEntry{
 		{
-			ExtraData: "bob the builder",
-			NumBlocks: 3,
-			Percent:   "50.00",
-			Aliases:   []string{"s3e6f", "s0e3f", "s0e2ts10e11t"},
+			Info: &database.TopBuilderEntry{
+				ExtraData: "builder0x69",
+				NumBlocks: 2,
+				Percent:   "66.67",
+			},
+			Children: []*database.TopBuilderEntry{
+				{
+					ExtraData: "made by builder0x69",
+					NumBlocks: 1,
+					Percent:   "33.33",
+					Aliases:   []string{"builder0x69"},
+				},
+				{
+					ExtraData: "builder0x69",
+					NumBlocks: 1,
+					Percent:   "33.33",
+					Aliases:   []string{"builder0x69"},
+				},
+			},
 		},
 		{
-			ExtraData: "builder0x69",
-			NumBlocks: 2,
-			Percent:   "33.33",
-			Aliases:   []string{"made by builder0x69", "builder0x69"},
-		},
-		{
-			ExtraData: "manta-builder",
-			Percent:   "16.67",
-			NumBlocks: 1,
+			Info: &database.TopBuilderEntry{
+				ExtraData: "foo-builder",
+				NumBlocks: 1,
+				Percent:   "33.33",
+			},
+			Children: []*database.TopBuilderEntry{},
 		},
 	}
 
@@ -147,4 +144,9 @@ func TestConsolidateBuilderProfitEntries(t *testing.T) {
 	for i, o := range out {
 		require.Equal(t, expected[i], o)
 	}
+}
+
+func TestLowercaseNoWhitespace(t *testing.T) {
+	c1 := lowercaseNoWhitespace("abCD 123!@#")
+	require.Equal(t, "abcd123!@#", c1)
 }

--- a/services/website/webserver.go
+++ b/services/website/webserver.go
@@ -333,9 +333,9 @@ func (srv *Webserver) handleDailyStatsJSON(w http.ResponseWriter, req *http.Requ
 	}
 
 	type apiResp struct {
-		Date     string                      `json:"date"`
-		Relays   []*database.TopRelayEntry   `json:"relays"`
-		Builders []*database.TopBuilderEntry `json:"builders"`
+		Date     string                             `json:"date"`
+		Relays   []*database.TopRelayEntry          `json:"relays"`
+		Builders []*database.TopBuilderDisplayEntry `json:"builders"`
 	}
 
 	resp := apiResp{
@@ -350,9 +350,9 @@ func (srv *Webserver) handleDailyStatsJSON(w http.ResponseWriter, req *http.Requ
 func (srv *Webserver) handleCowstatsJSON(w http.ResponseWriter, req *http.Request) {
 	// builder stats for wednesday utc 00:00 to next wednesday 00:00
 	type apiResp struct {
-		DateFrom    string                      `json:"date_from"`
-		DateTo      string                      `json:"date_to"`
-		TopBuilders []*database.TopBuilderEntry `json:"top_builders"`
+		DateFrom    string                             `json:"date_from"`
+		DateTo      string                             `json:"date_to"`
+		TopBuilders []*database.TopBuilderDisplayEntry `json:"top_builders"`
 	}
 
 	wednesday1 := getLastWednesday()

--- a/services/website/webserver.go
+++ b/services/website/webserver.go
@@ -333,9 +333,9 @@ func (srv *Webserver) handleDailyStatsJSON(w http.ResponseWriter, req *http.Requ
 	}
 
 	type apiResp struct {
-		Date     string                             `json:"date"`
-		Relays   []*database.TopRelayEntry          `json:"relays"`
-		Builders []*database.TopBuilderDisplayEntry `json:"builders"`
+		Date     string                    `json:"date"`
+		Relays   []*database.TopRelayEntry `json:"relays"`
+		Builders []*TopBuilderDisplayEntry `json:"builders"`
 	}
 
 	resp := apiResp{
@@ -350,9 +350,9 @@ func (srv *Webserver) handleDailyStatsJSON(w http.ResponseWriter, req *http.Requ
 func (srv *Webserver) handleCowstatsJSON(w http.ResponseWriter, req *http.Request) {
 	// builder stats for wednesday utc 00:00 to next wednesday 00:00
 	type apiResp struct {
-		DateFrom    string                             `json:"date_from"`
-		DateTo      string                             `json:"date_to"`
-		TopBuilders []*database.TopBuilderDisplayEntry `json:"top_builders"`
+		DateFrom    string                    `json:"date_from"`
+		DateTo      string                    `json:"date_to"`
+		TopBuilders []*TopBuilderDisplayEntry `json:"top_builders"`
 	}
 
 	wednesday1 := getLastWednesday()

--- a/services/website/webserver_data.go
+++ b/services/website/webserver_data.go
@@ -141,7 +141,7 @@ func (srv *Webserver) getStatsForHours(duration time.Duration) (stats *Stats, er
 		TopRelays:          prepareRelaysEntries(topRelays),
 		TopBuilders:        consolidateBuilderEntries(topBuilders),
 		BuilderProfits:     consolidateBuilderProfitEntries(builderProfits),
-		TopBuildersByRelay: make(map[string][]*database.TopBuilderEntry),
+		TopBuildersByRelay: make(map[string][]*database.TopBuilderDisplayEntry),
 	}
 
 	// Query builders for each relay

--- a/services/website/webserver_data.go
+++ b/services/website/webserver_data.go
@@ -141,7 +141,7 @@ func (srv *Webserver) getStatsForHours(duration time.Duration) (stats *Stats, er
 		TopRelays:          prepareRelaysEntries(topRelays),
 		TopBuilders:        consolidateBuilderEntries(topBuilders),
 		BuilderProfits:     consolidateBuilderProfitEntries(builderProfits),
-		TopBuildersByRelay: make(map[string][]*database.TopBuilderDisplayEntry),
+		TopBuildersByRelay: make(map[string][]*TopBuilderDisplayEntry),
 	}
 
 	// Query builders for each relay

--- a/static/styles.css
+++ b/static/styles.css
@@ -550,6 +550,10 @@ h1 {
     width: 99%;
 }
 
+.tr-builder-parent {
+    cursor: pointer;
+}
+
 .tr-builder-child {
     background-color: rgb(249 249 249);
 }

--- a/static/styles.css
+++ b/static/styles.css
@@ -550,6 +550,18 @@ h1 {
     width: 99%;
 }
 
+.tr-parent {
+    cursor: pointer;
+}
+
+.tr-child {
+    background-color: #999;
+}
+
+.td-builder-extradata-child {
+    margin-left: 5px;
+}
+
 .td-builder-percent {
     min-width: 106px;
 }

--- a/static/styles.css
+++ b/static/styles.css
@@ -550,12 +550,12 @@ h1 {
     width: 99%;
 }
 
-.tr-parent {
-    cursor: pointer;
+.tr-builder-child {
+    background-color: rgb(249 249 249);
 }
 
-.tr-child {
-    background-color: #999;
+.tr-builder-child td {
+    padding-left: 30px;
 }
 
 .td-builder-extradata-child {

--- a/vars/builder_aliases.go
+++ b/vars/builder_aliases.go
@@ -22,7 +22,7 @@ var BuilderAliases = map[string]func(string) bool{
 	},
 }
 
-var BuilderGroups = map[string]func(string) bool {
+var BuilderGroups = map[string]func(string) bool{
 	"BuilderNet": func(in string) bool {
 		return strings.Contains(in, "BuilderNet")
 	},

--- a/vars/builder_aliases.go
+++ b/vars/builder_aliases.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 )
 
-// BuilderAliases maps builder name to a function that returns if an input string (extra_data) is an alias
-var BuilderAliases = map[string]func(string) bool{
+// BuilderGroups maps builder name to a function that returns if an input string (extra_data) is an alias
+var BuilderGroups = map[string]func(string) bool{
 	"penguinbuild.org": func(in string) bool {
 		return strings.Contains(in, "penguinbuild.org")
 	},
@@ -20,9 +20,6 @@ var BuilderAliases = map[string]func(string) bool{
 		match, _ := regexp.MatchString("s[0-9]+e[0-9].*(t|f)", in)
 		return match
 	},
-}
-
-var BuilderGroups = map[string]func(string) bool{
 	"BuilderNet": func(in string) bool {
 		return strings.Contains(in, "BuilderNet")
 	},
@@ -30,7 +27,7 @@ var BuilderGroups = map[string]func(string) bool{
 
 // BuilderNameFromExtraData returns the builder name from the extra_data field
 func BuilderNameFromExtraData(extraData string) string {
-	for builder, aliasFunc := range BuilderAliases {
+	for builder, aliasFunc := range BuilderGroups {
 		if aliasFunc(extraData) {
 			return builder
 		}

--- a/vars/builder_aliases.go
+++ b/vars/builder_aliases.go
@@ -22,6 +22,12 @@ var BuilderAliases = map[string]func(string) bool{
 	},
 }
 
+var BuilderGroups = map[string]func(string) bool {
+	"BuilderNet": func(in string) bool {
+		return strings.Contains(in, "BuilderNet")
+	},
+}
+
 // BuilderNameFromExtraData returns the builder name from the extra_data field
 func BuilderNameFromExtraData(extraData string) string {
 	for builder, aliasFunc := range BuilderAliases {


### PR DESCRIPTION
## 📝 Summary

Often, builders use multiple extra data values.

Before, they were shown on hover:

![image](https://github.com/user-attachments/assets/d391e023-fbcb-4e54-8d49-15bcab705977)


Now they are shown as children, when there's more than one child:

![image](https://github.com/user-attachments/assets/99f447ae-bcfd-4b81-b570-21370ebadbce)

